### PR TITLE
ci: use client-id for the pre-commit autoupdate app token

### DIFF
--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -15,7 +15,7 @@ jobs:
         id: 'app-token'
         uses: 'actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1' # v3.2.0
         with:
-          app-id: '${{ vars.LF_AUTOMATION_APP_ID }}'
+          client-id: '${{ vars.LF_AUTOMATION_CLIENT_ID }}'
           private-key: '${{ secrets.LF_AUTOMATION_APP_PRIVATE_KEY }}'
 
       - name: 'Checkout repository'


### PR DESCRIPTION
`actions/create-github-app-token` v3 deprecates the `app-id` input in favour of `client-id`. This switches to `client-id`, read from the org variable `LF_AUTOMATION_CLIENT_ID`.