### PR TITLE
chore: unify pyproject.toml across repositories

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,11 +46,11 @@ Tracker = "https://github.com/linuxfabrik/checklistfabrik/issues/"
 generate-hashes = true
 
 [tool.setuptools.dynamic]
-dependencies = { file = "requirements.in" }
-version = { attr = "checklistfabrik.core.__version__" }
+dependencies = { file = 'requirements.in' }
+version = { attr = 'checklistfabrik.core.__version__' }
 
 [tool.setuptools.packages.find]
-where = ["src"]
+where = ['src']
 
 [project.optional-dependencies]
 pdf = [
@@ -66,40 +66,41 @@ clf-export = "checklistfabrik.core.cli.export:main"
 clf-play = "checklistfabrik.core.cli.play:main"
 
 [tool.pytest.ini_options]
-testpaths = ["tests"]
+testpaths = ['tests']
 
 [tool.ruff]
-line-length = 100
-target-version = "py39"
+line-length = 88
+target-version = 'py39'
 
 [tool.ruff.lint]
 select = [
-    "B",    # flake8-bugbear (potential bugs)
-    "C4",   # flake8-comprehensions
-    "E",    # pycodestyle errors
-    "F",    # pyflakes (logic errors)
-    "I",    # isort (import sorting)
-    "RUF",  # Ruff-specific rules
-    "SIM",  # flake8-simplify
-    "UP",   # pyupgrade (modernize syntax for py39+)
-    "W",    # pycodestyle warnings
+    'B',    # flake8-bugbear (potential bugs)
+    'C4',   # flake8-comprehensions
+    'E',    # pycodestyle errors
+    'F',    # pyflakes (logic errors)
+    'I',    # isort (import sorting)
+    'RUF',  # Ruff-specific rules
+    'SIM',  # flake8-simplify
+    'UP',   # pyupgrade (modernize syntax for py39+)
+    'W',    # pycodestyle warnings
 ]
 ignore = [
-    "E501",   # line too long (handled by code review, not auto-enforcement)
-    "UP009",  # UTF-8 encoding declaration (we keep our standard file header)
-    "UP015",  # redundant open() mode (we keep explicit modes for clarity)
+    'E501',   # line too long (handled by code review, not auto-enforcement)
+    'UP009',  # UTF-8 encoding declaration (we keep our standard file header)
+    'UP015',  # redundant open() mode (we keep explicit modes for clarity)
 ]
 
 [tool.ruff.format]
-quote-style = "single"
 docstring-code-format = true
+quote-style = 'single'
 
 [tool.bandit]
 # B110 (try/except/pass) and B112 (try/except/continue): intentional patterns
 # for graceful degradation.
 # B311 (pseudo-random): not used for cryptographic purposes.
-skips = ["B110", "B112", "B311"]
+skips = ['B110', 'B112', 'B311']
 
 [tool.bandit.assert_used]
-# pytest relies on the `assert` statement, so B101 does not apply to test files.
-skips = ["*/test_*.py", "*/conftest.py"]
+# pytest relies on the `assert` statement, so B101 does not apply under tests/.
+# bandit still scans the directory for every other finding.
+skips = ['*/tests/*.py', 'tests/*.py']

--- a/src/checklistfabrik/core/__main__.py
+++ b/src/checklistfabrik/core/__main__.py
@@ -11,7 +11,9 @@ def main():
         if entry_point.group == 'console_scripts'
     }
 
-    parser = argparse.ArgumentParser(prog='python -m checklistfabrik.core', add_help=False)
+    parser = argparse.ArgumentParser(
+        prog='python -m checklistfabrik.core', add_help=False
+    )
     parser.add_argument('entry_point', choices=entry_points.keys())
     args, extra = parser.parse_known_args()
 

--- a/src/checklistfabrik/core/checklist_data_mapper.py
+++ b/src/checklistfabrik/core/checklist_data_mapper.py
@@ -44,7 +44,9 @@ class ChecklistDataMapper:
             logger.critical('Cannot open file "%s" as it is a directory', file)
             raise ChecklistLoadError from error
         except PermissionError as error:
-            logger.critical('Cannot open file "%s" due to insufficient permissions', file)
+            logger.critical(
+                'Cannot open file "%s" due to insufficient permissions', file
+            )
             raise ChecklistLoadError from error
         except ruamel.yaml.YAMLError as error:
             logger.critical('Cannot parse file "%s": %s', file, error)
@@ -131,7 +133,9 @@ class ChecklistDataMapper:
                     file,
                 )
 
-        with open(file, mode='w' if overwrite else 'x', encoding='utf-8') as checklist_file:
+        with open(
+            file, mode='w' if overwrite else 'x', encoding='utf-8'
+        ) as checklist_file:
             stream.seek(0)
             checklist_file.write(stream.read())
 
@@ -192,11 +196,15 @@ class ChecklistDataMapper:
             raise ChecklistLoadError
 
         if 'description' in checklist and not isinstance(checklist['description'], str):
-            logger.critical('Description field of checklist "%s" is not a string', title)
+            logger.critical(
+                'Description field of checklist "%s" is not a string', title
+            )
             raise ChecklistLoadError
 
         if 'report_path' in checklist and not isinstance(checklist['report_path'], str):
-            logger.critical('Report path field of checklist "%s" is not a string', title)
+            logger.critical(
+                'Report path field of checklist "%s" is not a string', title
+            )
             raise ChecklistLoadError
 
         if 'version' in checklist and not isinstance(checklist['version'], str):
@@ -229,7 +237,9 @@ class ChecklistDataMapper:
 
             if page_directive == 'linuxfabrik.clf.import':
                 if not isinstance(page_context, str):
-                    logger.critical('Page import key is specified but its value is not a string')
+                    logger.critical(
+                        'Page import key is specified but its value is not a string'
+                    )
                     raise ChecklistLoadError
 
                 # Relative import paths should be relative to the checklist file.
@@ -256,7 +266,9 @@ class ChecklistDataMapper:
                 )
                 continue
 
-            pages.append(self.process_page(page, workdir, facts, is_template=is_template))
+            pages.append(
+                self.process_page(page, workdir, facts, is_template=is_template)
+            )
 
         return pages
 
@@ -285,7 +297,9 @@ class ChecklistDataMapper:
             raise ChecklistLoadError
 
         if task_list:
-            tasks = self.process_task_list(page['tasks'], workdir, facts, is_template=is_template)
+            tasks = self.process_task_list(
+                page['tasks'], workdir, facts, is_template=is_template
+            )
         else:
             logger.warning('Task list on page "%s" is empty', title)
             tasks = []
@@ -310,7 +324,9 @@ class ChecklistDataMapper:
 
             if task_module == 'linuxfabrik.clf.import':
                 if not isinstance(task_context, str):
-                    logger.critical('Task import key is specified but its value is not a string')
+                    logger.critical(
+                        'Task import key is specified but its value is not a string'
+                    )
                     raise ChecklistLoadError
 
                 # Relative import paths should be relative to the checklist file.
@@ -373,7 +389,12 @@ class ChecklistDataMapper:
 
             tasks.append(
                 models.Task(
-                    task_module, task_context, fact_name, when, unnamed_fact, workdir=workdir
+                    task_module,
+                    task_context,
+                    fact_name,
+                    when,
+                    unnamed_fact,
+                    workdir=workdir,
                 )
             )
 

--- a/src/checklistfabrik/core/checklist_wsgi_app.py
+++ b/src/checklistfabrik/core/checklist_wsgi_app.py
@@ -79,12 +79,18 @@ class ChecklistWsgiApp:
                     '/page/',
                     endpoint=lambda request: werkzeug.utils.redirect('/page/0'),
                 ),
-                werkzeug.routing.Rule('/page/<int:id>', endpoint=self.on_page_get, methods=['GET']),
+                werkzeug.routing.Rule(
+                    '/page/<int:id>', endpoint=self.on_page_get, methods=['GET']
+                ),
                 werkzeug.routing.Rule(
                     '/page/<int:id>', endpoint=self.on_page_post, methods=['POST']
                 ),
-                werkzeug.routing.Rule('/page/<int:id>/next', endpoint=self.on_next_page),
-                werkzeug.routing.Rule('/page/<int:id>/prev', endpoint=self.on_prev_page),
+                werkzeug.routing.Rule(
+                    '/page/<int:id>/next', endpoint=self.on_next_page
+                ),
+                werkzeug.routing.Rule(
+                    '/page/<int:id>/prev', endpoint=self.on_prev_page
+                ),
                 werkzeug.routing.Rule('/run', endpoint=self.on_run, methods=['POST']),
             ],
         )
@@ -110,7 +116,9 @@ class ChecklistWsgiApp:
         is_template = self.checklist_template is not None
         file_to_load = self.checklist_template if is_template else self.checklist_file
 
-        return self.checklist_mapper.load_checklist(file_to_load, is_template=is_template)
+        return self.checklist_mapper.load_checklist(
+            file_to_load, is_template=is_template
+        )
 
     def save_checklist(self):
         # On the very first save without a pre-set checklist file, pick a fresh path
@@ -123,9 +131,9 @@ class ChecklistWsgiApp:
 
     def _pick_initial_save_path(self):
         if self.checklist.report_path:
-            generated_filename = self.templ_env.from_string(self.checklist.report_path).render(
-                self.checklist.facts
-            )
+            generated_filename = self.templ_env.from_string(
+                self.checklist.report_path
+            ).render(self.checklist.facts)
 
             # Remove well-known invalid characters for the most commonly used operating
             # systems and filesystems.
@@ -144,20 +152,28 @@ class ChecklistWsgiApp:
             )
 
             candidate = pathlib.Path(os.path.expandvars(clean_filename))
-            logger.info('Generated file path based on template: "%s"', candidate.resolve())
+            logger.info(
+                'Generated file path based on template: "%s"', candidate.resolve()
+            )
         else:
-            candidate = pathlib.Path(f'checklist_{datetime.date.today().isoformat()}.yml')
+            candidate = pathlib.Path(
+                f'checklist_{datetime.date.today().isoformat()}.yml'
+            )
             logger.info('No report path configured. Using "%s"', candidate.resolve())
 
         # Find a free filename so we never overwrite an existing report on first save.
         original = candidate
         counter = 1
         while candidate.exists():
-            candidate = original.with_name(f'{original.stem}_{counter}{original.suffix}')
+            candidate = original.with_name(
+                f'{original.stem}_{counter}{original.suffix}'
+            )
             counter += 1
 
         if candidate != original:
-            logger.warning('File "%s" already exists. Saving to "%s" instead', original, candidate)
+            logger.warning(
+                'File "%s" already exists. Saving to "%s" instead', original, candidate
+            )
 
         return candidate
 
@@ -174,8 +190,8 @@ class ChecklistWsgiApp:
     def on_page_get(self, request, **kwargs):
         page_id = kwargs['id']
 
-        if page_id >= len(
-            self.checklist
+        if (
+            page_id >= len(self.checklist)
         ):  # page_id will always be an unsigned integer due to Werkzeug's IntegerConverter.
             raise werkzeug.exceptions.NotFound()
 
@@ -210,8 +226,8 @@ class ChecklistWsgiApp:
     def on_page_post(self, request, **kwargs):
         page_id = kwargs['id']
 
-        if page_id >= len(
-            self.checklist
+        if (
+            page_id >= len(self.checklist)
         ):  # page_id will always be an unsigned integer due to Werkzeug's IntegerConverter.
             raise werkzeug.exceptions.NotFound()
 
@@ -245,7 +261,9 @@ class ChecklistWsgiApp:
         self.save_checklist()
 
         if redirect.startswith('page '):
-            return werkzeug.utils.redirect(f'/page/{redirect.split(" ", maxsplit=1)[1]}')
+            return werkzeug.utils.redirect(
+                f'/page/{redirect.split(" ", maxsplit=1)[1]}'
+            )
 
         if redirect == 'next':
             return werkzeug.utils.redirect(f'/page/{page_id}/next')

--- a/src/checklistfabrik/core/cli/base_cli.py
+++ b/src/checklistfabrik/core/cli/base_cli.py
@@ -54,14 +54,24 @@ class BaseCli:
         os_name = platform.system()
 
         if os_name == 'Darwin':
-            log_path = pathlib.Path.home() / 'Library' / 'Logs' / root_module_name / log_file_name
+            log_path = (
+                pathlib.Path.home()
+                / 'Library'
+                / 'Logs'
+                / root_module_name
+                / log_file_name
+            )
         elif os_name == 'Linux':
             log_path = (
-                pathlib.Path(os.getenv('XDG_DATA_HOME', pathlib.Path.home() / '.local' / 'share'))
+                pathlib.Path(
+                    os.getenv('XDG_DATA_HOME', pathlib.Path.home() / '.local' / 'share')
+                )
                 / log_file_name
             )
         elif os_name == 'Windows' and 'APPDATA' in os.environ:
-            log_path = pathlib.Path(os.environ['APPDATA']) / root_module_name / log_file_name
+            log_path = (
+                pathlib.Path(os.environ['APPDATA']) / root_module_name / log_file_name
+            )
         else:
             log_path = pathlib.Path.cwd() / log_file_name
 
@@ -81,7 +91,9 @@ class BaseCli:
             file_handler = logging.FileHandler(log_path, mode='w')
             file_handler.setLevel(file_log_level)
             file_handler.setFormatter(
-                logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+                logging.Formatter(
+                    '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+                )
             )
 
             self.logger.addHandler(file_handler)

--- a/src/checklistfabrik/core/cli/export.py
+++ b/src/checklistfabrik/core/cli/export.py
@@ -118,7 +118,9 @@ class ExportCli(BaseCli):
             ),
         )
 
-    def init_logging(self, console_log_level=logging.INFO, file_log_level=logging.DEBUG, **kwargs):
+    def init_logging(
+        self, console_log_level=logging.INFO, file_log_level=logging.DEBUG, **kwargs
+    ):
         # Exported documents can go to stdout, so log messages must not.
         kwargs['console_stream'] = sys.stderr
 
@@ -132,10 +134,14 @@ class ExportCli(BaseCli):
 
         if self.args.output is not None:
             if self.args.output_dir is not None:
-                self.arg_parser.error('--output and --output-dir are mutually exclusive')
+                self.arg_parser.error(
+                    '--output and --output-dir are mutually exclusive'
+                )
 
             if len(self.sources) > 1:
-                self.arg_parser.error('--output may only be used when exporting a single file')
+                self.arg_parser.error(
+                    '--output may only be used when exporting a single file'
+                )
 
         self.output_format = self.args.format
 
@@ -163,7 +169,11 @@ class ExportCli(BaseCli):
                 found = [
                     match
                     for match in sorted(
-                        {match for pattern in REPORT_SUFFIXES for match in path.glob(pattern)}
+                        {
+                            match
+                            for pattern in REPORT_SUFFIXES
+                            for match in path.glob(pattern)
+                        }
                     )
                     if self.is_checklist(match)
                 ]
@@ -207,7 +217,9 @@ class ExportCli(BaseCli):
                 self.args.output_dir.mkdir(parents=True, exist_ok=True)
             except OSError as error:
                 logger.critical(
-                    'Cannot create output directory "%s": %s', self.args.output_dir, error
+                    'Cannot create output directory "%s": %s',
+                    self.args.output_dir,
+                    error,
                 )
                 return 1
 
@@ -221,7 +233,9 @@ class ExportCli(BaseCli):
                 failed += 1
 
         if failed:
-            logger.critical('%d of %d files failed to export', failed, len(self.sources))
+            logger.critical(
+                '%d of %d files failed to export', failed, len(self.sources)
+            )
             return 1
 
         return 0
@@ -229,7 +243,9 @@ class ExportCli(BaseCli):
     def export_source(self, source):
         """Export a single checklist file."""
 
-        logger.info('Exporting "%s" as %s', source, export.FORMATS[self.output_format]['label'])
+        logger.info(
+            'Exporting "%s" as %s', source, export.FORMATS[self.output_format]['label']
+        )
 
         checklist = self.load_checklist(source)
         data = export.export_checklist(
@@ -246,7 +262,9 @@ class ExportCli(BaseCli):
         target = (
             pathlib.Path(self.args.output)
             if self.args.output is not None
-            else export.output_path(source, self.output_format, output_dir=self.args.output_dir)
+            else export.output_path(
+                source, self.output_format, output_dir=self.args.output_dir
+            )
         )
 
         if target.resolve() in {candidate.resolve() for candidate in self.sources}:
@@ -266,7 +284,9 @@ class ExportCli(BaseCli):
 
         try:
             data = (
-                self.parsed[source] if source in self.parsed else self.data_mapper.load_yaml(source)
+                self.parsed[source]
+                if source in self.parsed
+                else self.data_mapper.load_yaml(source)
             )
 
             return self.data_mapper.process_checklist(

--- a/src/checklistfabrik/core/cli/play.py
+++ b/src/checklistfabrik/core/cli/play.py
@@ -125,14 +125,24 @@ class PlayCli(BaseCli):
         if self.args.report_file is None and self.args.template is None:
             # Dashboard mode.
             # Auto-detect well-known subdirectories if the user did not override.
-            if self.args.reports_dir == pathlib.Path('.') and pathlib.Path('reports').is_dir():
+            if (
+                self.args.reports_dir == pathlib.Path('.')
+                and pathlib.Path('reports').is_dir()
+            ):
                 self.args.reports_dir = pathlib.Path('reports')
-            if self.args.templates_dir == pathlib.Path('.') and pathlib.Path('templates').is_dir():
+            if (
+                self.args.templates_dir == pathlib.Path('.')
+                and pathlib.Path('templates').is_dir()
+            ):
                 self.args.templates_dir = pathlib.Path('templates')
             return
 
         if self.args.template is not None:
-            if self.args.report_file and self.args.report_file.is_file() and not self.args.force:
+            if (
+                self.args.report_file
+                and self.args.report_file.is_file()
+                and not self.args.force
+            ):
                 self.arg_parser.error(
                     '--template may only be specified if the report file does not exist'
                 )

--- a/src/checklistfabrik/core/dashboard_wsgi_app.py
+++ b/src/checklistfabrik/core/dashboard_wsgi_app.py
@@ -17,7 +17,9 @@ logger = logging.getLogger(__name__)
 class DashboardWsgiApp:
     """The WSGI app that powers the ChecklistFabrik dashboard."""
 
-    def __init__(self, templates_dir, reports_dir, data_mapper, template_loader, assets_dir):
+    def __init__(
+        self, templates_dir, reports_dir, data_mapper, template_loader, assets_dir
+    ):
         self.assets_dir = assets_dir
         self.data_mapper = data_mapper
         self.reports_dir = reports_dir
@@ -36,7 +38,9 @@ class DashboardWsgiApp:
         self.url_map = werkzeug.routing.Map(
             [
                 werkzeug.routing.Rule('/', endpoint=self.on_dashboard),
-                werkzeug.routing.Rule('/export', endpoint=self.on_export, methods=['GET']),
+                werkzeug.routing.Rule(
+                    '/export', endpoint=self.on_export, methods=['GET']
+                ),
                 werkzeug.routing.Rule('/run', endpoint=self.on_run, methods=['POST']),
                 werkzeug.routing.Rule('/view', endpoint=self.on_view, methods=['POST']),
             ],
@@ -73,11 +77,17 @@ class DashboardWsgiApp:
         if not directory.is_dir():
             return items
 
-        for path in sorted(list(directory.glob('*.yml')) + list(directory.glob('*.yaml'))):
+        for path in sorted(
+            list(directory.glob('*.yml')) + list(directory.glob('*.yaml'))
+        ):
             try:
                 data = self.data_mapper.load_yaml(path)
 
-                if not isinstance(data, dict) or 'title' not in data or 'pages' not in data:
+                if (
+                    not isinstance(data, dict)
+                    or 'title' not in data
+                    or 'pages' not in data
+                ):
                     continue
 
                 items.append(
@@ -142,7 +152,11 @@ class DashboardWsgiApp:
                 report.parent,
             )
             data = export.export_checklist(checklist, output_format, source=report.name)
-        except (ValueError, checklist_data_mapper.ChecklistLoadError, export.ExportError) as error:
+        except (
+            ValueError,
+            checklist_data_mapper.ChecklistLoadError,
+            export.ExportError,
+        ) as error:
             logger.error('Cannot export "%s" as %s: %s', report, output_format, error)
 
             return werkzeug.Response(

--- a/src/checklistfabrik/core/export/markup.py
+++ b/src/checklistfabrik/core/export/markup.py
@@ -22,7 +22,9 @@ import mistune
 
 # Same plugin set as the HTML interface, minus `speedup` which only tunes the HTML
 # renderer and has no effect on the abstract syntax tree.
-_parse_markdown = mistune.create_markdown(renderer=None, plugins=['strikethrough', 'table'])
+_parse_markdown = mistune.create_markdown(
+    renderer=None, plugins=['strikethrough', 'table']
+)
 
 _HTML_TAG = re.compile(r'<[^>]+>')
 _TRAILING_UNDERSCORE = re.compile(r'_(?=\s|$)')
@@ -113,7 +115,11 @@ class MarkupWriter:
         return '\n\n'.join(block for block in blocks if block)
 
     def render_blocks(self, tokens):
-        return [block for block in (self.render_block(token) for token in tokens or []) if block]
+        return [
+            block
+            for block in (self.render_block(token) for token in tokens or [])
+            if block
+        ]
 
     def render_block(self, token):
         node_type = token['type']
@@ -130,7 +136,9 @@ class MarkupWriter:
             return self.render_inline(token.get('children'))
 
         if node_type == 'heading':
-            return self.heading(self.render_inline(token.get('children')), attrs.get('level', 1))
+            return self.heading(
+                self.render_inline(token.get('children')), attrs.get('level', 1)
+            )
 
         if node_type == 'thematic_break':
             return self.thematic_break()
@@ -139,7 +147,9 @@ class MarkupWriter:
             return self.code_block(token.get('raw', ''), attrs.get('info'))
 
         if node_type == 'block_quote':
-            return self.quote(self.join_blocks(self.render_blocks(token.get('children'))))
+            return self.quote(
+                self.join_blocks(self.render_blocks(token.get('children')))
+            )
 
         if node_type == 'list':
             return self.render_list(token)
@@ -188,7 +198,10 @@ class MarkupWriter:
                 ]
             elif section['type'] == 'table_body':
                 rows = [
-                    [self.render_inline(cell.get('children')) for cell in row.get('children') or []]
+                    [
+                        self.render_inline(cell.get('children'))
+                        for cell in row.get('children') or []
+                    ]
                     for row in section.get('children') or []
                 ]
 
@@ -208,16 +221,22 @@ class MarkupWriter:
             elif node_type == 'emphasis':
                 parts.append(self.emphasis(self.render_inline(token.get('children'))))
             elif node_type == 'strikethrough':
-                parts.append(self.strikethrough(self.render_inline(token.get('children'))))
+                parts.append(
+                    self.strikethrough(self.render_inline(token.get('children')))
+                )
             elif node_type == 'codespan':
                 parts.append(self.codespan(token.get('raw', '')))
             elif node_type == 'link':
                 parts.append(
-                    self.link(self.render_inline(token.get('children')), attrs.get('url', ''))
+                    self.link(
+                        self.render_inline(token.get('children')), attrs.get('url', '')
+                    )
                 )
             elif node_type == 'image':
                 parts.append(
-                    self.image(self.render_inline(token.get('children')), attrs.get('url', ''))
+                    self.image(
+                        self.render_inline(token.get('children')), attrs.get('url', '')
+                    )
                 )
             elif node_type == 'linebreak':
                 parts.append(self.linebreak())
@@ -548,10 +567,14 @@ class HtmlWriter(MarkupWriter):
     """
 
     def render_inline(self, tokens):
-        raise NotImplementedError('HtmlWriter renders whole blocks; use split_lead_html')
+        raise NotImplementedError(
+            'HtmlWriter renders whole blocks; use split_lead_html'
+        )
 
     def render_nodes(self, nodes):
-        raise NotImplementedError('HtmlWriter renders whole blocks; use split_lead_html')
+        raise NotImplementedError(
+            'HtmlWriter renders whole blocks; use split_lead_html'
+        )
 
     def __init__(self):
         # Not the renderer of the interactive interface: that one adds a JavaScript-driven

--- a/src/checklistfabrik/core/export/renderers/asciidoc.py
+++ b/src/checklistfabrik/core/export/renderers/asciidoc.py
@@ -221,4 +221,6 @@ def _reference(block, writer):
 
     extra.append(f'Checklist: `+{block["path"]}+`')
 
-    return _item(writer, block['label'], marker(block['checked']), block['required'], extra=extra)
+    return _item(
+        writer, block['label'], marker(block['checked']), block['required'], extra=extra
+    )

--- a/src/checklistfabrik/core/export/renderers/html.py
+++ b/src/checklistfabrik/core/export/renderers/html.py
@@ -145,7 +145,9 @@ def _escape(text):
 
 
 def _required(html, required):
-    return f'{html} <span class="clf-required">({REQUIRED})</span>' if required else html
+    return (
+        f'{html} <span class="clf-required">({REQUIRED})</span>' if required else html
+    )
 
 
 def _metadata(document):
@@ -234,7 +236,9 @@ def _checklist(block, writer):
         return checklist
 
     return '{}\n{}\n{}'.format(
-        f'<div class="clf-label">{_required(head, block["required"])}</div>' if head else '',
+        f'<div class="clf-label">{_required(head, block["required"])}</div>'
+        if head
+        else '',
         rest,
         checklist,
     ).strip()
@@ -264,7 +268,11 @@ def _field(block, writer):
     if not head and not rest:
         return value
 
-    label = f'<div class="clf-label">{_required(head, block["required"])}</div>' if head else ''
+    label = (
+        f'<div class="clf-label">{_required(head, block["required"])}</div>'
+        if head
+        else ''
+    )
 
     return f'{label}\n{rest}\n<div class="clf-value">{value}</div>'.strip()
 
@@ -303,6 +311,8 @@ def _reference(block, writer):
         f'<p class="clf-reference-path">Checklist: <code>{_escape(block["path"])}</code></p>'
     )
 
-    item = _item(writer, block['label'], marker(block['checked']), block['required'], extra=extra)
+    item = _item(
+        writer, block['label'], marker(block['checked']), block['required'], extra=extra
+    )
 
     return f'<ul class="clf-checklist clf-reference">\n{item}\n</ul>'

--- a/src/checklistfabrik/core/export/renderers/markdown.py
+++ b/src/checklistfabrik/core/export/renderers/markdown.py
@@ -140,7 +140,9 @@ def _item(writer, label, item_marker, required, extra=()):
     if required:
         head = _required(head, True) if head else f'*({REQUIRED})*'
 
-    blocks = [block for block in [head, writer.render_nodes(rest), *extra] if block] or [NO_LABEL]
+    blocks = [
+        block for block in [head, writer.render_nodes(rest), *extra] if block
+    ] or [NO_LABEL]
     body = '\n\n'.join(blocks)
 
     if head:
@@ -212,4 +214,6 @@ def _reference(block, writer):
 
     extra.append(f'Checklist: `{block["path"]}`')
 
-    return _item(writer, block['label'], marker(block['checked']), block['required'], extra=extra)
+    return _item(
+        writer, block['label'], marker(block['checked']), block['required'], extra=extra
+    )

--- a/src/checklistfabrik/core/export/renderers/pdf.py
+++ b/src/checklistfabrik/core/export/renderers/pdf.py
@@ -81,7 +81,9 @@ class InlineWriter(markup.MarkupWriter):
     def escape(self, text):
         # fpdf2 reads a marker literally when an odd number of backslashes precedes it.
         # Existing backslashes are doubled so that the added one always wins.
-        escaped = _FPDF_MARKER.sub(lambda match: f'{match.group(1) * 2}\\{match.group(2)}', text)
+        escaped = _FPDF_MARKER.sub(
+            lambda match: f'{match.group(1) * 2}\\{match.group(2)}', text
+        )
 
         # An unescaped bracket could start a link.
         return escaped.replace('[', '\\[')
@@ -181,7 +183,9 @@ def _text(text):
     encoded = text.encode('latin-1', errors='replace')
 
     if b'?' in encoded and '?' not in text:
-        logger.warning('PDF export replaced characters that the built-in fonts cannot display')
+        logger.warning(
+            'PDF export replaced characters that the built-in fonts cannot display'
+        )
 
     return encoded.decode('latin-1')
 
@@ -190,7 +194,9 @@ def _required(text, required):
     return f'{text} ({REQUIRED})' if required else text
 
 
-def _write(pdf, text, style='', size=SIZE_BODY, font=FONT, indent=0, markdown=False, fill=False):
+def _write(
+    pdf, text, style='', size=SIZE_BODY, font=FONT, indent=0, markdown=False, fill=False
+):
     """Write a block of text, wrapping it and starting a new page where needed.
 
     `markdown` hands the emphasis markers of `InlineWriter` over to fpdf2. It must stay off
@@ -359,7 +365,12 @@ def _markdown_node(pdf, node, writer, indent):
         return
 
     if node_type in ('paragraph', 'block_text'):
-        _write(pdf, writer.render_inline(node.get('children')), indent=indent, markdown=True)
+        _write(
+            pdf,
+            writer.render_inline(node.get('children')),
+            indent=indent,
+            markdown=True,
+        )
         _spacer(pdf)
     elif node_type == 'heading':
         _write(
@@ -531,5 +542,12 @@ def _reference(pdf, block, writer):
 
     extra = [description, path] if block['description'] else [path]
 
-    _item(pdf, block['label'], marker(block['checked']), block['required'], writer, extra=extra)
+    _item(
+        pdf,
+        block['label'],
+        marker(block['checked']),
+        block['required'],
+        writer,
+        extra=extra,
+    )
     _spacer(pdf)

--- a/src/checklistfabrik/core/export/renderers/rst.py
+++ b/src/checklistfabrik/core/export/renderers/rst.py
@@ -143,7 +143,9 @@ def _item(writer, label, item_marker, required, extra=()):
     if required:
         head = f'{head} *({REQUIRED})*' if head else f'*({REQUIRED})*'
 
-    blocks = [block for block in [head, writer.render_nodes(rest), *extra] if block] or [NO_LABEL]
+    blocks = [
+        block for block in [head, writer.render_nodes(rest), *extra] if block
+    ] or [NO_LABEL]
     body = '\n\n'.join(blocks)
 
     # The bullet is `- `, so everything below the first line lines up two columns in.
@@ -225,7 +227,9 @@ def _reference(block, writer):
 
     extra.append(f'Checklist: ``{block["path"]}``')
 
-    return _item(writer, block['label'], marker(block['checked']), block['required'], extra=extra)
+    return _item(
+        writer, block['label'], marker(block['checked']), block['required'], extra=extra
+    )
 
 
 def _directive(name, content):

--- a/src/checklistfabrik/core/markdown.py
+++ b/src/checklistfabrik/core/markdown.py
@@ -15,7 +15,8 @@ class ClfHtmlRenderer(mistune.HTMLRenderer):
         if lines and lines[-1] == '':
             lines = lines[:-1]
         wrapped = ''.join(
-            f'<span class="clf-code-line">{mistune.util.escape(line)}</span>' for line in lines
+            f'<span class="clf-code-line">{mistune.util.escape(line)}</span>'
+            for line in lines
         )
 
         return (

--- a/src/checklistfabrik/core/models/checklist.py
+++ b/src/checklistfabrik/core/models/checklist.py
@@ -1,7 +1,9 @@
 class Checklist:
     """Models a ChecklistFabrik checklist."""
 
-    def __init__(self, title, pages, facts, description=None, report_path=None, version=None):
+    def __init__(
+        self, title, pages, facts, description=None, report_path=None, version=None
+    ):
         self.description = description
         self.facts = facts
         self.pages = pages

--- a/src/checklistfabrik/core/models/page.py
+++ b/src/checklistfabrik/core/models/page.py
@@ -79,6 +79,8 @@ class Page:
             data = '<div class="toast toast-primary">This page was marked as not applicable based on previous input.</div>'
 
         return TEMPLATE_FORMAT_STRING.format(
-            title=markupsafe.escape(template_env.from_string(self.title).render(**facts)),
+            title=markupsafe.escape(
+                template_env.from_string(self.title).render(**facts)
+            ),
             data=data,
         )

--- a/src/checklistfabrik/core/models/task.py
+++ b/src/checklistfabrik/core/models/task.py
@@ -25,7 +25,9 @@ def _keep_markdown(text):
 class Task:
     """Models a ChecklistFabrik checklist task."""
 
-    def __init__(self, module, context, fact_name, when, unnamed_fact=None, workdir=None):
+    def __init__(
+        self, module, context, fact_name, when, unnamed_fact=None, workdir=None
+    ):
         self.module = module
         self.context = context
         self.fact_name = fact_name
@@ -143,7 +145,10 @@ class Task:
                 exception,
             )
             result['blocks'] = [
-                blocks.note(f'Exporting module "{self.module}" failed: {exception}', level='error'),
+                blocks.note(
+                    f'Exporting module "{self.module}" failed: {exception}',
+                    level='error',
+                ),
             ]
             return result
 
@@ -155,7 +160,9 @@ class Task:
                 type({}),
             )
             result['blocks'] = [
-                blocks.note(f'Module "{self.module}" returned an invalid export.', level='error'),
+                blocks.note(
+                    f'Module "{self.module}" returned an invalid export.', level='error'
+                ),
             ]
             return result
 
@@ -180,9 +187,13 @@ class Task:
         ]
 
         if self.fact_name and self.fact_name in facts:
-            label = self.context.get('label') if isinstance(self.context, dict) else None
+            label = (
+                self.context.get('label') if isinstance(self.context, dict) else None
+            )
             fallback.append(
-                blocks.field(label or self.fact_name, blocks.values_of(facts[self.fact_name]))
+                blocks.field(
+                    label or self.fact_name, blocks.values_of(facts[self.fact_name])
+                )
             )
 
         return fallback
@@ -204,7 +215,9 @@ class Task:
             safe_module = markupsafe.escape(self.module)
             return f'<div class="toast toast-error">Task rendering error: Cannot find module <em>{safe_module}</em>. Is it installed?</div>'
 
-        render_context = self.build_context(facts, template_env, markdown, template_env_plain)
+        render_context = self.build_context(
+            facts, template_env, markdown, template_env_plain
+        )
 
         if not hasattr(loaded_module, 'main') or not callable(loaded_module.main):
             logger.error(

--- a/src/checklistfabrik/core/spawner.py
+++ b/src/checklistfabrik/core/spawner.py
@@ -40,7 +40,9 @@ def launch_checklist(
     """
     path = checklist_file or checklist_template
 
-    if allowed_dir is not None and not path.resolve().is_relative_to(allowed_dir.resolve()):
+    if allowed_dir is not None and not path.resolve().is_relative_to(
+        allowed_dir.resolve()
+    ):
         raise werkzeug.exceptions.Forbidden()
 
     if not path.is_file():

--- a/src/checklistfabrik/modules/linuxfabrik/clf/html.py
+++ b/src/checklistfabrik/modules/linuxfabrik/clf/html.py
@@ -19,7 +19,9 @@ def main(**kwargs):
     # used instead.
     clf_jinja_env_plain = kwargs['clf_jinja_env_plain']
 
-    rendered_content = clf_jinja_env_plain.from_string(kwargs['content']).render(**kwargs)
+    rendered_content = clf_jinja_env_plain.from_string(kwargs['content']).render(
+        **kwargs
+    )
 
     return {
         'html': f'<div class="clf-content-block">{rendered_content}</div>',
@@ -31,6 +33,8 @@ def export(**kwargs):
 
     return {
         'blocks': [
-            blocks.html(clf_jinja_env_plain.from_string(kwargs['content']).render(**kwargs)),
+            blocks.html(
+                clf_jinja_env_plain.from_string(kwargs['content']).render(**kwargs)
+            ),
         ],
     }

--- a/src/checklistfabrik/modules/linuxfabrik/clf/markdown.py
+++ b/src/checklistfabrik/modules/linuxfabrik/clf/markdown.py
@@ -38,6 +38,8 @@ def export(**kwargs):
 
     return {
         'blocks': [
-            blocks.markdown(clf_jinja_env_plain.from_string(kwargs['content']).render(**kwargs)),
+            blocks.markdown(
+                clf_jinja_env_plain.from_string(kwargs['content']).render(**kwargs)
+            ),
         ],
     }

--- a/src/checklistfabrik/modules/linuxfabrik/clf/radio_input.py
+++ b/src/checklistfabrik/modules/linuxfabrik/clf/radio_input.py
@@ -100,7 +100,9 @@ def export(**kwargs):
     # the label the user actually selected and falls back to the raw value if the option
     # is no longer part of the checklist.
     selected = [
-        blocks.plain_text(clf_jinja_env_plain.from_string(radio['label']).render(**kwargs))
+        blocks.plain_text(
+            clf_jinja_env_plain.from_string(radio['label']).render(**kwargs)
+        )
         if radio.get('label')
         else str(radio.get('value', ''))
         for radio in kwargs.get('values', [])
@@ -110,7 +112,9 @@ def export(**kwargs):
     return {
         'blocks': [
             blocks.field(
-                clf_jinja_env_plain.from_string(kwargs.get('label', '')).render(**kwargs),
+                clf_jinja_env_plain.from_string(kwargs.get('label', '')).render(
+                    **kwargs
+                ),
                 selected or blocks.values_of(fact_value),
                 required=kwargs.get('required'),
             ),

--- a/src/checklistfabrik/modules/linuxfabrik/clf/run_template.py
+++ b/src/checklistfabrik/modules/linuxfabrik/clf/run_template.py
@@ -64,9 +64,7 @@ TEMPLATE_STRING = """\
 </div>
 """
 
-ERROR_TEMPLATE = (
-    '<div class="toast toast-error"><em>linuxfabrik.clf.run_template</em>: {message}</div>'
-)
+ERROR_TEMPLATE = '<div class="toast toast-error"><em>linuxfabrik.clf.run_template</em>: {message}</div>'
 
 
 def _error(message):
@@ -132,12 +130,14 @@ def _resolve_target(**kwargs):
         {
             'display_path': str(rendered_path),
             'resolved_path': str(target),
-            'templated_description': clf_jinja_env_plain.from_string(str(raw_description)).render(
-                **kwargs
-            )
+            'templated_description': clf_jinja_env_plain.from_string(
+                str(raw_description)
+            ).render(**kwargs)
             if raw_description
             else '',
-            'templated_title': clf_jinja_env_plain.from_string(str(raw_title)).render(**kwargs),
+            'templated_title': clf_jinja_env_plain.from_string(str(raw_title)).render(
+                **kwargs
+            ),
         },
         None,
     )
@@ -155,7 +155,9 @@ def main(**kwargs):
 
     templated_title = clf_markdown(target['templated_title'])
     templated_description = (
-        clf_markdown(target['templated_description']) if target['templated_description'] else ''
+        clf_markdown(target['templated_description'])
+        if target['templated_description']
+        else ''
     )
 
     return {
@@ -182,7 +184,9 @@ def export(**kwargs):
 
     if target is None:
         return {
-            'blocks': [blocks.note(f'linuxfabrik.clf.run_template: {message}', level='error')],
+            'blocks': [
+                blocks.note(f'linuxfabrik.clf.run_template: {message}', level='error')
+            ],
         }
 
     return {

--- a/src/checklistfabrik/modules/linuxfabrik/clf/select_input.py
+++ b/src/checklistfabrik/modules/linuxfabrik/clf/select_input.py
@@ -65,7 +65,8 @@ def main(**kwargs):
     )
 
     templated_values = [
-        clf_jinja_env.from_string(value).render(**kwargs) for value in kwargs.get('values', [''])
+        clf_jinja_env.from_string(value).render(**kwargs)
+        for value in kwargs.get('values', [''])
     ]
 
     if kwargs.get('multiple'):
@@ -110,7 +111,9 @@ def export(**kwargs):
     return {
         'blocks': [
             blocks.field(
-                clf_jinja_env_plain.from_string(kwargs.get('label', '')).render(**kwargs),
+                clf_jinja_env_plain.from_string(kwargs.get('label', '')).render(
+                    **kwargs
+                ),
                 blocks.values_of(kwargs.get(fact_name)),
                 required=kwargs.get('required'),
             ),

--- a/src/checklistfabrik/modules/linuxfabrik/clf/text_input.py
+++ b/src/checklistfabrik/modules/linuxfabrik/clf/text_input.py
@@ -60,7 +60,9 @@ def export(**kwargs):
     return {
         'blocks': [
             blocks.field(
-                clf_jinja_env_plain.from_string(kwargs.get('label', '')).render(**kwargs),
+                clf_jinja_env_plain.from_string(kwargs.get('label', '')).render(
+                    **kwargs
+                ),
                 blocks.values_of(kwargs.get(fact_name)),
                 required=kwargs.get('required'),
             ),

--- a/src/checklistfabrik/modules/linuxfabrik/clf/textarea_input.py
+++ b/src/checklistfabrik/modules/linuxfabrik/clf/textarea_input.py
@@ -65,7 +65,9 @@ def export(**kwargs):
     return {
         'blocks': [
             blocks.field(
-                clf_jinja_env_plain.from_string(kwargs.get('label', '')).render(**kwargs),
+                clf_jinja_env_plain.from_string(kwargs.get('label', '')).render(
+                    **kwargs
+                ),
                 blocks.values_of(kwargs.get(fact_name)),
                 monospace=kwargs.get('monospace'),
                 required=kwargs.get('required'),

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -36,10 +36,15 @@ class TestRstWriter:
         writer = markup.RstWriter()
         assert writer.render('**bold** and *italic*') == '**bold** and *italic*'
         assert writer.render('`code`') == '``code``'
-        assert writer.render('[text](https://example.com)') == '`text <https://example.com>`_'
+        assert (
+            writer.render('[text](https://example.com)')
+            == '`text <https://example.com>`_'
+        )
 
     def test_escapes_literal_markup_characters(self):
-        assert markup.RstWriter().render('2 * 3 and a | pipe') == r'2 \* 3 and a \| pipe'
+        assert (
+            markup.RstWriter().render('2 * 3 and a | pipe') == r'2 \* 3 and a \| pipe'
+        )
 
     def test_headings_become_bold_paragraphs(self):
         # An arbitrary heading level inside a task would break the section hierarchy of
@@ -76,7 +81,9 @@ class TestMarkdownWriter:
         assert writer.render('~~gone~~') == '~~gone~~'
 
     def test_headings_are_shifted_below_the_page_heading(self):
-        assert markup.MarkdownWriter().render('# Top\n\n## Sub\n') == '### Top\n\n#### Sub'
+        assert (
+            markup.MarkdownWriter().render('# Top\n\n## Sub\n') == '### Top\n\n#### Sub'
+        )
 
     def test_heading_shift_is_relative_to_the_topmost_heading(self):
         assert markup.MarkdownWriter().render('### Only') == '### Only'
@@ -92,7 +99,9 @@ class TestAsciiDocWriter:
         writer = markup.AsciiDocWriter()
         assert writer.render('**bold**') == '*bold*'
         assert writer.render('`code`') == '`+code+`'
-        assert writer.render('[text](https://example.com)') == 'https://example.com[text]'
+        assert (
+            writer.render('[text](https://example.com)') == 'https://example.com[text]'
+        )
 
     def test_nested_list_repeats_the_marker(self):
         # AsciiDoc reads an indented line as a literal block.
@@ -152,7 +161,11 @@ class TestDocument:
         ]
 
     def test_excluded_page_is_kept_but_flagged(self, sample_document):
-        assert [page['applicable'] for page in sample_document['pages']] == [True, True, False]
+        assert [page['applicable'] for page in sample_document['pages']] == [
+            True,
+            True,
+            False,
+        ]
 
     def test_progress_ignores_excluded_pages(self, sample_document):
         # ticket, maintenance type, two pre-flight items, command output, reboot duration.
@@ -218,7 +231,9 @@ class TestModuleExport:
         from checklistfabrik.modules.linuxfabrik.clf import text_input
 
         result = text_input.export(
-            **_export_kwargs(fact_name='host', host='server01', label='Host', required=True)
+            **_export_kwargs(
+                fact_name='host', host='server01', label='Host', required=True
+            )
         )
 
         assert result['fact_name'] == 'host'
@@ -236,7 +251,9 @@ class TestModuleExport:
         from checklistfabrik.modules.linuxfabrik.clf import textarea_input
 
         result = textarea_input.export(
-            **_export_kwargs(fact_name='out', label='Output', monospace=True, out='a\nb')
+            **_export_kwargs(
+                fact_name='out', label='Output', monospace=True, out='a\nb'
+            )
         )
 
         assert result['blocks'][0]['monospace'] is True
@@ -246,7 +263,9 @@ class TestModuleExport:
         from checklistfabrik.modules.linuxfabrik.clf import select_input
 
         result = select_input.export(
-            **_export_kwargs(fact_name='langs', label='Languages', langs=['Python', 'Go'])
+            **_export_kwargs(
+                fact_name='langs', label='Languages', langs=['Python', 'Go']
+            )
         )
 
         assert result['blocks'][0]['values'] == ['Python', 'Go']
@@ -310,7 +329,9 @@ class TestModuleExport:
         from checklistfabrik.modules.linuxfabrik.clf import checkbox_input
 
         result = checkbox_input.export(
-            **_export_kwargs(fact_name='accept', accept='on', label='Accept', required=True)
+            **_export_kwargs(
+                fact_name='accept', accept='on', label='Accept', required=True
+            )
         )
 
         assert result['blocks'][0]['items'] == [
@@ -363,7 +384,9 @@ class TestModuleExport:
         from checklistfabrik.modules.linuxfabrik.clf import run_template
 
         result = run_template.export(
-            **_export_kwargs(clf_task_workdir=tmp_path, fact_name='done', path='missing.yml')
+            **_export_kwargs(
+                clf_task_workdir=tmp_path, fact_name='done', path='missing.yml'
+            )
         )
 
         assert result['blocks'][0]['type'] == 'note'
@@ -396,7 +419,9 @@ class TestRstRenderer:
         assert 'Reboot duration\n   *not answered*' in rst.render(sample_document)
 
     def test_multiline_value_becomes_a_literal_block(self, sample_document):
-        assert '::\n\n      first line\n      second line' in rst.render(sample_document)
+        assert '::\n\n      first line\n      second line' in rst.render(
+            sample_document
+        )
 
     def test_checklist_markers(self, sample_document):
         result = rst.render(sample_document)
@@ -448,8 +473,9 @@ class TestAsciiDocRenderer:
         assert '* [x] Notify users' in asciidoc.render(sample_document)
 
     def test_excluded_page_gets_an_admonition(self, sample_document):
-        assert '[NOTE]\n====\nThis page was marked as not applicable' in asciidoc.render(
-            sample_document
+        assert (
+            '[NOTE]\n====\nThis page was marked as not applicable'
+            in asciidoc.render(sample_document)
         )
 
 
@@ -493,14 +519,18 @@ class TestHtmlRenderer:
 
 class TestPdfRenderer:
     def test_renders_a_pdf(self, sample_document):
-        pytest.importorskip('fpdf', reason='PDF export needs the optional fpdf2 package')
+        pytest.importorskip(
+            'fpdf', reason='PDF export needs the optional fpdf2 package'
+        )
 
         data = export.render(sample_document, 'pdf')
 
         assert data.startswith(b'%PDF-')
 
     def test_renders_structured_markdown(self, data_mapper, tmp_path):
-        pytest.importorskip('fpdf', reason='PDF export needs the optional fpdf2 package')
+        pytest.importorskip(
+            'fpdf', reason='PDF export needs the optional fpdf2 package'
+        )
 
         report = tmp_path / 'structure.yml'
         report.write_text(
@@ -552,7 +582,9 @@ class TestPdfRenderer:
 
         assert pdf.plain_inline(lead['children']) == 'Full update'
 
-    def test_missing_dependency_raises_an_export_error(self, monkeypatch, sample_document):
+    def test_missing_dependency_raises_an_export_error(
+        self, monkeypatch, sample_document
+    ):
         from checklistfabrik.core.export.renderers import pdf
 
         def no_fpdf():
@@ -585,12 +617,14 @@ class TestExportApi:
         assert export.format_from_suffix(path) == expected
 
     def test_output_path_replaces_the_extension(self):
-        assert export.output_path('reports/run.yml', 'rst') == pathlib.Path('reports/run.rst')
+        assert export.output_path('reports/run.yml', 'rst') == pathlib.Path(
+            'reports/run.rst'
+        )
 
     def test_output_path_honours_the_output_directory(self):
-        assert export.output_path('reports/run.yml', 'markdown', output_dir='out') == pathlib.Path(
-            'out/run.md'
-        )
+        assert export.output_path(
+            'reports/run.yml', 'markdown', output_dir='out'
+        ) == pathlib.Path('out/run.md')
 
     def test_unknown_format_raises(self, sample_document):
         with pytest.raises(export.ExportError, match='Unknown output format'):
@@ -622,7 +656,9 @@ def _run_cli(monkeypatch, tmp_path, argv):
 
 class TestExportCli:
     def test_writes_next_to_the_report(self, monkeypatch, tmp_path, sample_report_yaml):
-        code = _run_cli(monkeypatch, tmp_path, [str(sample_report_yaml), '--format', 'rst'])
+        code = _run_cli(
+            monkeypatch, tmp_path, [str(sample_report_yaml), '--format', 'rst']
+        )
 
         assert code == 0
         assert (tmp_path / 'report.rst').read_text().startswith('====')
@@ -632,25 +668,37 @@ class TestExportCli:
     ):
         target = tmp_path / 'out' / 'report.md'
         target.parent.mkdir()
-        code = _run_cli(monkeypatch, tmp_path, [str(sample_report_yaml), '--output', str(target)])
+        code = _run_cli(
+            monkeypatch, tmp_path, [str(sample_report_yaml), '--output', str(target)]
+        )
 
         assert code == 0
         assert target.read_text().startswith('# Server Maintenance')
 
     def test_writes_to_stdout(self, capsys, monkeypatch, tmp_path, sample_report_yaml):
         code = _run_cli(
-            monkeypatch, tmp_path, [str(sample_report_yaml), '--format', 'rst', '--output', '-']
+            monkeypatch,
+            tmp_path,
+            [str(sample_report_yaml), '--format', 'rst', '--output', '-'],
         )
 
         assert code == 0
         assert 'Server Maintenance INC-4711' in capsys.readouterr().out
 
-    def test_output_directory_is_created(self, monkeypatch, tmp_path, sample_report_yaml):
+    def test_output_directory_is_created(
+        self, monkeypatch, tmp_path, sample_report_yaml
+    ):
         target_dir = tmp_path / 'exports'
         code = _run_cli(
             monkeypatch,
             tmp_path,
-            [str(sample_report_yaml), '--format', 'asciidoc', '--output-dir', str(target_dir)],
+            [
+                str(sample_report_yaml),
+                '--format',
+                'asciidoc',
+                '--output-dir',
+                str(target_dir),
+            ],
         )
 
         assert code == 0
@@ -672,7 +720,9 @@ class TestExportCli:
         # A directory of checklists usually also holds files that only contain a page or
         # task list for an import.
         fragment = tmp_path / 'import-additional-tasks.yml'
-        fragment.write_text('- linuxfabrik.clf.html:\n    content: Fragment\n', encoding='utf-8')
+        fragment.write_text(
+            '- linuxfabrik.clf.html:\n    content: Fragment\n', encoding='utf-8'
+        )
 
         code = _run_cli(monkeypatch, tmp_path, [str(tmp_path), '--format', 'rst'])
 
@@ -680,9 +730,13 @@ class TestExportCli:
         assert (tmp_path / 'report.rst').is_file()
         assert not (tmp_path / 'import-additional-tasks.rst').exists()
 
-    def test_metadata_can_be_switched_off(self, monkeypatch, tmp_path, sample_report_yaml):
+    def test_metadata_can_be_switched_off(
+        self, monkeypatch, tmp_path, sample_report_yaml
+    ):
         code = _run_cli(
-            monkeypatch, tmp_path, [str(sample_report_yaml), '--format', 'rst', '--no-metadata']
+            monkeypatch,
+            tmp_path,
+            [str(sample_report_yaml), '--format', 'rst', '--no-metadata'],
         )
 
         assert code == 0
@@ -708,15 +762,25 @@ class TestExportCli:
 
     def test_named_import_fragment_exits_non_zero(self, monkeypatch, tmp_path):
         fragment = tmp_path / 'tasks.yml'
-        fragment.write_text('- linuxfabrik.clf.html:\n    content: Fragment\n', encoding='utf-8')
+        fragment.write_text(
+            '- linuxfabrik.clf.html:\n    content: Fragment\n', encoding='utf-8'
+        )
 
         assert _run_cli(monkeypatch, tmp_path, [str(fragment), '--format', 'rst']) == 1
 
-    def test_refuses_to_overwrite_the_report(self, monkeypatch, tmp_path, sample_report_yaml):
+    def test_refuses_to_overwrite_the_report(
+        self, monkeypatch, tmp_path, sample_report_yaml
+    ):
         code = _run_cli(
             monkeypatch,
             tmp_path,
-            [str(sample_report_yaml), '--format', 'rst', '--output', str(sample_report_yaml)],
+            [
+                str(sample_report_yaml),
+                '--format',
+                'rst',
+                '--output',
+                str(sample_report_yaml),
+            ],
         )
 
         assert code == 1
@@ -727,7 +791,9 @@ class TestExportCli:
     ):
         assert _run_cli(monkeypatch, tmp_path, [str(sample_report_yaml)]) == 2
 
-    def test_output_rejects_several_reports(self, monkeypatch, tmp_path, sample_report_yaml):
+    def test_output_rejects_several_reports(
+        self, monkeypatch, tmp_path, sample_report_yaml
+    ):
         second = tmp_path / 'second.yml'
         second.write_text(sample_report_yaml.read_text(), encoding='utf-8')
 
@@ -747,7 +813,12 @@ class TestExportCli:
         assert code == 2
 
     def test_missing_input_is_rejected(self, monkeypatch, tmp_path):
-        assert _run_cli(monkeypatch, tmp_path, [str(tmp_path / 'nope.yml'), '--format', 'rst']) == 2
+        assert (
+            _run_cli(
+                monkeypatch, tmp_path, [str(tmp_path / 'nope.yml'), '--format', 'rst']
+            )
+            == 2
+        )
 
 
 # --- dashboard export endpoint ---
@@ -778,21 +849,30 @@ class TestDashboardExport:
 
     def test_export_is_served_as_a_download(self, dashboard_client):
         client, report = dashboard_client
-        response = client.get('/export', query_string={'format': 'rst', 'path': str(report)})
+        response = client.get(
+            '/export', query_string={'format': 'rst', 'path': str(report)}
+        )
 
         assert response.status_code == 200
-        assert response.headers['Content-Disposition'] == 'attachment; filename="report.rst"'
+        assert (
+            response.headers['Content-Disposition']
+            == 'attachment; filename="report.rst"'
+        )
         assert 'Server Maintenance INC-4711' in response.get_data(as_text=True)
 
     def test_path_outside_the_reports_directory_is_forbidden(self, dashboard_client):
         client, _report = dashboard_client
-        response = client.get('/export', query_string={'format': 'rst', 'path': '/etc/passwd'})
+        response = client.get(
+            '/export', query_string={'format': 'rst', 'path': '/etc/passwd'}
+        )
 
         assert response.status_code == 403
 
     def test_unknown_format_is_rejected(self, dashboard_client):
         client, report = dashboard_client
-        response = client.get('/export', query_string={'format': 'docx', 'path': str(report)})
+        response = client.get(
+            '/export', query_string={'format': 'docx', 'path': str(report)}
+        )
 
         assert response.status_code == 400
 
@@ -812,7 +892,9 @@ class TestDashboardExport:
             raise export.ExportError('no renderer today')
 
         monkeypatch.setattr(export, 'export_checklist', fail)
-        response = client.get('/export', query_string={'format': 'pdf', 'path': str(report)})
+        response = client.get(
+            '/export', query_string={'format': 'pdf', 'path': str(report)}
+        )
 
         assert response.status_code == 500
         assert 'no renderer today' in response.get_data(as_text=True)

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -68,7 +68,9 @@ class TestMarkdownModule:
         # Mistune's HTML escaping exactly once (`"` -> `&quot;`), not twice
         # (`"` -> `&#34;` -> `&amp;#34;`). This happened when the content went
         # through an autoescape-enabled Jinja environment before Mistune.
-        result = markdown.main(**_make_kwargs(content='`{{ greeting }}`', greeting='say "hi"'))
+        result = markdown.main(
+            **_make_kwargs(content='`{{ greeting }}`', greeting='say "hi"')
+        )
         assert '&quot;' in result['html']
         assert '&amp;' not in result['html']
 
@@ -486,7 +488,9 @@ class TestRunTemplateModule:
         assert 'Original description.' not in result['html']
 
     def test_missing_path_yields_error(self, tmp_path):
-        result = run_template.main(**_make_kwargs(clf_task_workdir=tmp_path, fact_name='run_done'))
+        result = run_template.main(
+            **_make_kwargs(clf_task_workdir=tmp_path, fact_name='run_done')
+        )
         assert 'toast-error' in result['html']
         assert 'path' in result['html']
 


### PR DESCRIPTION
The lint configuration grew per repository in April 2026 instead of from a shared template, and firewallfabrik and mcp-server-icinga came from a different project skeleton. That left four dialects behind.

Unified: `line-length` is now stated explicitly as 88 everywhere (the ruff default; checklistfabrik was the outlier at 100), `[tool.ruff.format]` is byte-identical in all six repositories that run ruff, the `select` list is alphabetical, `[tool.bandit.assert_used]` uses one pattern, and strings inside `[tool.*]` are single-quoted. `[build-system]`, `[project]` and `[tool.setuptools]` are left alone: those are per-project and double quotes are the ecosystem norm there.

`target-version`, the `ignore` lists and the extra `PTH`/`TID` rules stay per repository, they follow from the codebase.